### PR TITLE
Fixes tutorials for first time use

### DIFF
--- a/1-hello-world/hello_world.py
+++ b/1-hello-world/hello_world.py
@@ -24,7 +24,7 @@ while True:
 
     for packet in data_packets:
           data = packet.getData()
-          print("Received %s packet with shape=%s" % packet.stream_name, str(data.shape))
+          print("Received %s packet with shape=%s" % (packet.stream_name, str(data.shape)))
 
     if cv2.waitKey(1) == ord('q'):
         break

--- a/2-face-detection-retail/face-detection-retail-0004.py
+++ b/2-face-detection-retail/face-detection-retail-0004.py
@@ -17,8 +17,8 @@ p = depthai.create_pipeline(
         'ai':
         {
             # The paths below are based on the tutorial steps.
-            'blob_file': "/home/pi/open_model_zoo_downloads/Retail/object_detection/face/sqnet1.0modif-ssd/0004/dldt/FP16/face-detection-retail-0004.blob",
-            'blob_file_config': "/home/pi/open_model_zoo_downloads/Retail/object_detection/face/sqnet1.0modif-ssd/0004/dldt/FP16/face-detection-retail-0004.json"
+            'blob_file': "face-detection-retail-0004.blob",
+            'blob_file_config': "face-detection-retail-0004.json"
         }
     }
 )


### PR DESCRIPTION
There were two errors, one in each of the tutorials. The first was the print format wasn't using a tuple and the second was using absolute paths instead of relative path.